### PR TITLE
add before_install section into .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: haskell
+
+before_install:
+  - sudo apt-get install -qq libxxf86vm-dev


### PR DESCRIPTION
add before_install: into travis.yml to install dependent C library.
missing C library causes following error:

``` log
setup-Cabal-1.16.0-x86_64-linux-ghc-7.6.3: Missing dependency on a foreign
library:
* Missing C library: Xxf86vm
```
