### PR TITLE
bump up cabal constraint OpenGLRaw

### DIFF
--- a/free-game.cabal
+++ b/free-game.cabal
@@ -64,7 +64,7 @@ library
     linear >= 1.0 && < 2,
     mtl >= 2.1,
     OpenGL == 2.9.*,
-    OpenGLRaw == 1.4.*,
+    OpenGLRaw == 1.5.*,
     random == 1.*,
     reflection == 1.*,
     template-haskell,


### PR DESCRIPTION
problem of OpenGLRaw package dependency #31.

Tested on ghc 7.6.3 and ghc 7.8.3 in Ubuntu 14.04.1 LTS.
Both build passed and example works fine!

``` log
== 1.4.* ->
== 1.5.*
```
