### PR TITLE
use ExceptT

### DIFF
--- a/FreeGame/Instances.hs
+++ b/FreeGame/Instances.hs
@@ -9,7 +9,11 @@ import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Cont
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.List
+#if MIN_VERSION_transformers(0,4,0)
+import Control.Monad.Trans.Except
+#else
 import Control.Monad.Trans.Error
+#endif
 import Control.Monad.Trans.Identity
 import qualified Control.Monad.State.Lazy as Lazy
 import qualified Control.Monad.State.Strict as Strict
@@ -97,7 +101,11 @@ MK_AFFINE(_COMMA_ Monad m _COMMA_ Monoid w, Strict.RWST r w s m, Strict.mapRWST)
 MK_AFFINE(_COMMA_ Monad m, IdentityT m, mapIdentityT)
 MK_AFFINE(_COMMA_ Monad m, MaybeT m, mapMaybeT)
 MK_AFFINE(_COMMA_ Monad m, ListT m, mapListT)
+#if MIN_VERSION_transformers(0,4,0)
+MK_AFFINE(_COMMA_ Monad m, ExceptT e m, mapExceptT)
+#else
 MK_AFFINE(_COMMA_ Monad m _COMMA_ Error e, ErrorT e m, mapErrorT)
+#endif
 MK_AFFINE(_COMMA_ Monad m, ContT r m, mapContT)
 
 MK_PICTURE_2D(_COMMA_ Functor m, F m, Church.liftF, hoistF)
@@ -113,7 +121,11 @@ MK_PICTURE_2D(_COMMA_ Monad m _COMMA_ Monoid w, Strict.RWST r w s m, lift, Stric
 MK_PICTURE_2D(_COMMA_ Monad m, IdentityT m, lift, mapIdentityT)
 MK_PICTURE_2D(_COMMA_ Monad m, MaybeT m, lift, mapMaybeT)
 MK_PICTURE_2D(_COMMA_ Monad m, ListT m, lift, mapListT)
+#if MIN_VERSION_transformers(0,4,0)
+MK_PICTURE_2D(_COMMA_ Monad m, ExceptT e m, lift, mapExceptT)
+#else
 MK_PICTURE_2D(_COMMA_ Monad m _COMMA_ Error e, ErrorT e m, lift, mapErrorT)
+#endif
 MK_PICTURE_2D(_COMMA_ Monad m, ContT r m, lift, mapContT)
 
 MK_LOCAL(_COMMA_ Functor m, F m, Church.liftF)
@@ -129,7 +141,11 @@ MK_LOCAL(_COMMA_ Monad m _COMMA_ Monoid w, Strict.RWST r w s m, lift)
 MK_LOCAL(_COMMA_ Monad m, IdentityT m, lift)
 MK_LOCAL(_COMMA_ Monad m, MaybeT m, lift)
 MK_LOCAL(_COMMA_ Monad m, ListT m, lift)
+#if MIN_VERSION_transformers(0,4,0)
+MK_LOCAL(_COMMA_ Monad m, ExceptT e m, lift)
+#else
 MK_LOCAL(_COMMA_ Monad m _COMMA_ Error e, ErrorT e m, lift)
+#endif
 MK_LOCAL(_COMMA_ Monad m, ContT r m, lift)
 
 MK_KEYBOARD(_COMMA_ Functor m, F m, Church.liftF)
@@ -145,7 +161,11 @@ MK_KEYBOARD(_COMMA_ Monad m _COMMA_ Monoid w, Strict.RWST r w s m, lift)
 MK_KEYBOARD(_COMMA_ Monad m, IdentityT m, lift)
 MK_KEYBOARD(_COMMA_ Monad m, MaybeT m, lift)
 MK_KEYBOARD(_COMMA_ Monad m, ListT m, lift)
+#if MIN_VERSION_transformers(0,4,0)
+MK_KEYBOARD(_COMMA_ Monad m, ExceptT e m, lift)
+#else
 MK_KEYBOARD(_COMMA_ Monad m _COMMA_ Error e, ErrorT e m, lift)
+#endif
 MK_KEYBOARD(_COMMA_ Monad m, ContT r m, lift)
 
 MK_MOUSE(_COMMA_ Functor m, F m, liftF)
@@ -161,7 +181,11 @@ MK_MOUSE(_COMMA_ Monad m _COMMA_ Monoid w, Strict.RWST r w s m, lift)
 MK_MOUSE(_COMMA_ Monad m, IdentityT m, lift)
 MK_MOUSE(_COMMA_ Monad m, MaybeT m, lift)
 MK_MOUSE(_COMMA_ Monad m, ListT m, lift)
+#if MIN_VERSION_transformers(0,4,0)
+MK_MOUSE(_COMMA_ Monad m, ExceptT e m, lift)
+#else
 MK_MOUSE(_COMMA_ Monad m _COMMA_ Error e, ErrorT e m, lift)
+#endif
 MK_MOUSE(_COMMA_ Monad m, ContT r m, lift)
 
 MK_FROM_FINALIZER(_COMMA_ Functor m, F m, liftF)
@@ -176,7 +200,11 @@ MK_FROM_FINALIZER(_COMMA_ Monad m _COMMA_ Monoid w, Strict.RWST r w s m, lift)
 MK_FROM_FINALIZER(_COMMA_ Monad m, IdentityT m, lift)
 MK_FROM_FINALIZER(_COMMA_ Monad m, MaybeT m, lift)
 MK_FROM_FINALIZER(_COMMA_ Monad m, ListT m, lift)
+#if MIN_VERSION_transformers(0,4,0)
+MK_FROM_FINALIZER(_COMMA_ Monad m, ExceptT e m, lift)
+#else
 MK_FROM_FINALIZER(_COMMA_ Monad m _COMMA_ Error e, ErrorT e m, lift)
+#endif
 MK_FROM_FINALIZER(_COMMA_ Monad m, ContT r m, lift)
 
 MK_FREE_GAME(_COMMA_ Functor m, F m, liftF)
@@ -191,5 +219,9 @@ MK_FREE_GAME(_COMMA_ Monad m _COMMA_ Monoid w, Strict.RWST r w s m, lift)
 MK_FREE_GAME(_COMMA_ Monad m, IdentityT m, lift)
 MK_FREE_GAME(_COMMA_ Monad m, MaybeT m, lift)
 MK_FREE_GAME(_COMMA_ Monad m, ListT m, lift)
+#if MIN_VERSION_transformers(0,4,0)
+MK_FREE_GAME(_COMMA_ Monad m, ExceptT e m, lift)
+#else
 MK_FREE_GAME(_COMMA_ Monad m _COMMA_ Error e, ErrorT e m, lift)
+#endif
 MK_FREE_GAME(_COMMA_ Monad m, ContT r m, lift)


### PR DESCRIPTION
In mtl-2.2 `ErrorT` and `Error` are deprecated. see: https://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Error.html

> Deprecated: Use Control.Monad.Except instead

So, it replaces:
- `ErrorT` -> `ExceptT`
- `mapErrorT` -> `mapExceptT`

And it is breaking changes.

``` c
#if MIN_VERSION_transformers(0,4,0)
```

Using above macro makes be able to compile under `transformers < 0.4.0` environment. 
